### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/ffs/ffs.py
+++ b/dissect/ffs/ffs.py
@@ -56,9 +56,10 @@ class FFS:
         self.mount_name = bytes(self.sb.fs_fsmnt).split(b"\x00")[0].decode(errors="surrogateescape")
         self.volume_name = bytes(self.sb.fs_volname).split(b"\x00")[0].decode(errors="surrogateescape")
 
+        self.cylinder_group = lru_cache(1024)(self.cylinder_group)
+        self.inode = lru_cache(4096)(self.inode)
+
         self.root = self.inode(c_ffs.UFS_ROOTINO, "/")
-        lru_cache(1024)(self.cylinder_group)
-        lru_cache(4096)(self.inode)
 
     @staticmethod
     def read_sb(fh, offset):


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)